### PR TITLE
Feature: New syntax "t::group" and Deprecate old "T_SUB" syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,27 @@ t_error     $cmd  "cmd fails"         # $cmd; [ $? -ne 0 ]
 This feature works like `subtest` of
 [Test::More](http://perldoc.perl.org/Test/More.html).
 
-**New special syntax is introduced in v0.7.0:**
+New special syntax is introduced in v0.8.1:
 
 ```sh
 t_ok $ok
 
+t::group "level1 group" ({
+  t_ok $lv1_ok
+
+  t::group "level2 group" ({
+    t_ok $lv2_ok
+    t_is $lv2_a $lv2_b
+  })
+})
+```
+
+This is compatiable with the syntax introduced in v0.7.0:
+
+```sh
+t_ok $ok
+
+# Deprecated: Use "t::group ({})" instead
 T_SUB "level1 group" ((
   t_ok $lv1_ok
 
@@ -131,7 +147,7 @@ T_SUB "level1 group" ((
 ))
 ```
 
-The codes above is the same as following codes:
+These codes are the same as following codes:
 
 ```sh
 t_ok $ok
@@ -155,6 +171,11 @@ So you can run them in different context from main tests context.
 
 If you want test groups A and B not affect to each other, you have to put them in
 different groups.
+
+**CAUTION:
+
+- The old grouping syntax `T_SUB (( ... ))` will be unsupported in the future
+release.**
 
 # Authors
 

--- a/lib/shove.bashrc
+++ b/lib/shove.bashrc
@@ -58,14 +58,21 @@ test_file() {
     _add "__t_verbose=1"
   fi
   cat $_t | while read line; do
-    if [[ "$line" =~ ^[[:space:]]*T_SUB[[:space:]]*.*\(\($ ]]; then
+    if [[ "$line" =~ ^[[:space:]]*t::group[[:space:]]*.*\(\{$ ]]; then
+      #echo "# '$line' matches group beginning."
+      _item="$(echo $line | sed -e 's/^t::group //' | sed -e 's/ ({$//')"
+      subtests+=("${_item}")
+      _add '('
+      : $((_lv += 1))
+      _add "t_substart ${_item}"
+    elif [[ "$line" =~ ^[[:space:]]*T_SUB[[:space:]]*.*\(\($ ]]; then
       #echo "# '$line' matches group beginning."
       _item="$(echo $line | sed -e 's/^T_SUB //' | sed -e 's/ (($//')"
       subtests+=("${_item}")
       _add '('
       : $((_lv += 1))
       _add "t_substart ${_item}"
-    elif [[ "$line" =~ ^[[:space:]]*\)\)$ ]]; then
+    elif [[ "$line" =~ ^[[:space:]]*[\}\)]\)$ ]]; then
       #echo "# '$line' matches group ending."
       declare -i num=${#subtests[@]}
       last=$((num - 1))

--- a/t/group-ex.t
+++ b/t/group-ex.t
@@ -1,9 +1,19 @@
 t_ok ok
 
-T_SUB "child group" ((
+T_SUB "child group 1" ((
   t_ok c1
 
-  T_SUB "grand child" ((
+  T_SUB "grand child 1" ((
     t_ok gc1
   ))
+
+  t::group "grand child 2" ({
+    t_ok gc2
+  })
 ))
+
+t::group "child child 2" ({
+  t_ok c2
+})
+
+# vim:set ft=sh :


### PR DESCRIPTION
Please be carefull about that "T_SUB" syntax will be unsupported in the future release.
