### PR TITLE
Use realpath instead of readlink

### DIFF
--- a/bin/shove
+++ b/bin/shove
@@ -6,7 +6,7 @@ version="0.8.1"
 
 bin_path=$0
 if [[ -L $0 ]]; then
-  bin_path=$(readlink $0)
+  bin_path=$(realpath $0)
 fi
 
 bin_dir=$(cd $(dirname ${bin_path}) && pwd)


### PR DESCRIPTION
`readlink` does not return absolute path of `shove`, which causes the problem in later `cd`. Use `realpath` can solve the problem by providing absolute path.
